### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,12 @@
 <html lang="pt-BR">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Cartão – Charles Rezende Freitas</title>
 
     <!-- Font (Google) + Ícones (Font-Awesome) -->
     <link href="https://fonts.googleapis.com/css2?family=Questrial&display=swap" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" integrity="sha512-..."
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet"
           crossorigin="anonymous"/>
 
     <link rel="stylesheet" href="style.css">

--- a/style.css
+++ b/style.css
@@ -13,6 +13,9 @@ body{
     color:#000;
     background:#fff;
     line-height:1.35;
+    display:flex;
+    flex-direction:column;
+    min-height:100vh;
 }
 
 /* ------------- BANNER ------------- */
@@ -107,27 +110,33 @@ main{
 
 /* ------------- MEDIA QUERIES ESPECÍFICAS ------------- */
 
-/* ≤ 600 px: empilha logo e foto, centraliza */
+/* ≤ 600 px: mantém elementos lado a lado */
 @media (max-width:600px){
     .banner{
-        flex-direction:column;
-        align-items:flex-start;
+        flex-direction:row;
+        align-items:center;
     }
     .banner::before{
-        width:100%;
-        border-bottom-right-radius:0;
+        width:65%;
+        border-bottom-right-radius:240px;
     }
     .logo{
-        margin-left:0;
-        margin-top:1.2rem;
+        margin-left:auto;
+        margin-top:0;
+    }
+    .contact-list li{
+        font-size:clamp(1.15rem,4.8vw,1.5rem);
+    }
+    .icon{
+        width:clamp(48px,12vw,60px);
+        height:clamp(48px,12vw,60px);
+        font-size:clamp(22px,5vw,30px);
     }
 }
 
 /* ≥ 1280 px: limita largura total para evitar linhas muito longas */
 @media (min-width:1280px){
     body{
-        display:flex;
-        flex-direction:column;
         align-items:center;
     }
     header,main,.footer-art{


### PR DESCRIPTION
## Summary
- add meta viewport for proper scaling
- tweak contact list sizing on small screens
- let body fill the viewport
- simplify Font Awesome link integrity
- adjust banner layout on small screens to keep the logo beside the photo

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68627cb4b2588321a745364f8600dce2