### PR TITLE
Enable multilingual contact label

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,13 +55,13 @@
         <li>
             <span class="icon card"><i class="fas fa-id-card"></i></span>
             <a href="https://charlesrzf.github.io/card/charlesrf.vcf"
-             id="save-contact" download="charlesrf.vcf"> salvar contato </a>
+             id="save-contact" download="charlesrf.vcf">Salvar contato</a>
         </li>
     </ul>
 </main>
 
 <footer class="footer-art"></footer>
 
-<script src="script.js"></script>
+<script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,13 +1,28 @@
-/* Faz o link “salvar contato” baixar o vCard */
-document.getElementById('save-contact').addEventListener('click', function (e) {
-    e.preventDefault();
-    /* coloque charlesrf.vcf na raiz do site */
-   const vcfUrl = 'https://charlesrzf.github.io/card/charlesrf.vcf';
+/*
+ * Ajusta o texto do link de download do vCard de acordo com o idioma do
+ * navegador e aciona o download quando clicado.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    const link = document.getElementById('save-contact');
+    if (!link) return;
 
-    const link = document.createElement('a');
-    link.href = vcfUrl;
-    link.download = 'charlesrf.vcf';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    const lang = (navigator.language || 'en').toLowerCase().slice(0, 2);
+    const labels = {
+        pt: 'Salvar contato',
+        es: 'Guardar contacto',
+        en: 'Save contact'
+    };
+    link.textContent = labels[lang] || labels.en;
+
+    link.addEventListener('click', function (e) {
+        e.preventDefault();
+        /* coloque charlesrf.vcf na raiz do site */
+        const vcfUrl = 'https://charlesrzf.github.io/card/charlesrf.vcf';
+        const temp = document.createElement('a');
+        temp.href = vcfUrl;
+        temp.download = 'charlesrf.vcf';
+        document.body.appendChild(temp);
+        temp.click();
+        document.body.removeChild(temp);
+    });
 });


### PR DESCRIPTION
## Summary
- allow `Salvar contato` link to change language based on browser
- fix JavaScript filename reference

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc02f07883219f70d3debb73e71b